### PR TITLE
Fix issue with the shipping property

### DIFF
--- a/store/models.py
+++ b/store/models.py
@@ -45,6 +45,9 @@ class Order(models.Model):
 		for i in orderitems:
 			if i.product.digital == False:
 				shipping = True
+			elif i.product.digital == True:
+                		shipping = False
+                		break
 		return shipping
 
 	@property


### PR DESCRIPTION
Sometimes the one of the items has the digital property as False, but then other item overrides this and the shipping form keeps showing.